### PR TITLE
[Feat/#14] 로그인뷰 UI 디자인 변경

### DIFF
--- a/Projects/Presentation/Login/Sources/LoginView.swift
+++ b/Projects/Presentation/Login/Sources/LoginView.swift
@@ -77,7 +77,7 @@ struct LoginView: View {
         RoundedRectangle(cornerRadius: LoginButtonConstants.cornerRadius)
           .fill(color)
           .frame(width: .infinity, height: LoginButtonConstants.height)
-          .padding(.horizontal, 16)
+          .padding(.horizontal, 13)
           
         HStack {
           Image(asset: icon)

--- a/Projects/Presentation/Login/Sources/LoginView.swift
+++ b/Projects/Presentation/Login/Sources/LoginView.swift
@@ -15,51 +15,51 @@ struct LoginView: View {
   }
   
   var body: some View {
-    VStack {
+    VStack(spacing: 0) {
       Spacer()
-        .frame(height: 383)
+        .frame(height: 329)
       
-      VStack(alignment: .leading) {
+      VStack(alignment: .leading, spacing: 0) {
         RoundedRectangle(cornerRadius: 5)
           .stroke(Color.gray)
           .fill(Color.nutral200)
           .frame(width: 102, height: 102)
+          .padding(.bottom, 16)
         
-        Group {
-          Text("안녕하세요!")
-          Text("두런이와 함께 뛰어요!")
-        }
-        .jalnan(.regular, size: 26)
-        .foregroundStyle(Color.primary200)
+        Text("안녕하세요!\n두런이와 함께 뛰어요!")
+          .frame(height: 70)
+          .lineSpacing(8)
+          .jalnan(.regular, size: 26)
+          .foregroundStyle(Color.primary200)
+          .padding(.bottom, 8)
         
         Text("혼자도, 함께도 즐기는 비대면 러닝크루")
           .suit(.medium, size: 15)
           .foregroundStyle(Color.nutral600)
-          .padding(.top, 2)
+          .padding(.bottom, 63)
       }
       .frame(maxWidth: .infinity, alignment: .leading)
       .padding(.leading, 16)
-      .padding(.bottom, 63)
       
-      
-      
-      createLoginButton(
-        title: "카카오로 시작하기",
-        color: Color(red: 0.996, green: 0.898, blue: 0.0, opacity: 1.0),
-        textColor: Color.black,
-        icon: DesignSystemAsset.Icons.kakao20
-      ) {
+      VStack(spacing: 8) {
+        createLoginButton(
+          title: "카카오로 시작하기",
+          color: Color(red: 0.996, green: 0.898, blue: 0.0, opacity: 1.0),
+          textColor: Color.black,
+          icon: DesignSystemAsset.Icons.kakao20
+        ) {
           // store로 action 전달 필요
         }
-      
-      createLoginButton(
-        title: "Apple로 시작하기",
-        color: Color.black,
-        textColor: Color.white,
-        icon: DesignSystemAsset.Icons.apple20
-      ) {
+        
+        createLoginButton(
+          title: "Apple로 시작하기",
+          color: Color.black,
+          textColor: Color.white,
+          icon: DesignSystemAsset.Icons.apple20
+        ) {
           // store로 action 전달 필요
         }
+      }
     }
   }
   

--- a/Projects/Presentation/Login/Sources/LoginView.swift
+++ b/Projects/Presentation/Login/Sources/LoginView.swift
@@ -17,25 +17,31 @@ struct LoginView: View {
   var body: some View {
     VStack {
       Spacer()
+        .frame(height: 383)
       
-      Rectangle()
-        .fill(Color.gray)
-        .frame(width: 100, height: 100)
-      
-      Group {
-        Text("안녕하세요!")
-        Text("저 두런이와 함께 뛸 준비 되셨나요?")
-      }
-      .font(.custom("Jalnan2", size: 20))
-
-      Text("혼자 또는 같이 즐기는 비대면 러닝크루, 두런두런입니다.")
+      VStack(alignment: .leading) {
+        RoundedRectangle(cornerRadius: 5)
+          .stroke(Color.gray)
+          .fill(Color.nutral200)
+          .frame(width: 102, height: 102)
+        
+        Group {
+          Text("안녕하세요!")
+          Text("두런이와 함께 뛰어요!")
+        }
         .jalnan(.regular, size: 26)
         .foregroundStyle(Color.primary200)
-        .padding(.top, 8)
+        
+        Text("혼자도, 함께도 즐기는 비대면 러닝크루")
           .suit(.medium, size: 15)
           .foregroundStyle(Color.nutral600)
+          .padding(.top, 2)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.leading, 16)
+      .padding(.bottom, 63)
       
-      Spacer()
+      
       
       createLoginButton(
         title: "카카오로 시작하기",

--- a/Projects/Presentation/Login/Sources/LoginView.swift
+++ b/Projects/Presentation/Login/Sources/LoginView.swift
@@ -47,7 +47,7 @@ struct LoginView: View {
         title: "카카오로 시작하기",
         color: Color(red: 0.996, green: 0.898, blue: 0.0, opacity: 1.0),
         textColor: Color.black,
-        icon: DesignSystemAsset.Icons.kakao20.name
+        icon: DesignSystemAsset.Icons.kakao20
       ) {
           // store로 action 전달 필요
         }
@@ -56,7 +56,7 @@ struct LoginView: View {
         title: "Apple로 시작하기",
         color: Color.black,
         textColor: Color.white,
-        icon: DesignSystemAsset.Icons.apple20.name
+        icon: DesignSystemAsset.Icons.apple20
       ) {
           // store로 action 전달 필요
         }
@@ -67,7 +67,7 @@ struct LoginView: View {
       title: String,
       color: Color,
       textColor: Color,
-      icon: String,
+      icon: DesignSystemImages,
       action: @escaping () -> Void
   ) -> some View {
     Button {
@@ -80,7 +80,7 @@ struct LoginView: View {
           .padding(.horizontal, 16)
           
         HStack {
-          Image(icon)
+          Image(asset: icon)
         
           Text(title)
             .suit(.medium, size: 15)

--- a/Projects/Presentation/Login/Sources/LoginView.swift
+++ b/Projects/Presentation/Login/Sources/LoginView.swift
@@ -29,9 +29,11 @@ struct LoginView: View {
       .font(.custom("Jalnan2", size: 20))
 
       Text("혼자 또는 같이 즐기는 비대면 러닝크루, 두런두런입니다.")
+        .jalnan(.regular, size: 26)
         .foregroundStyle(Color.primary200)
-        .font(.custom("Pretendard-Regular.otf", size: 13))
         .padding(.top, 8)
+          .suit(.medium, size: 15)
+          .foregroundStyle(Color.nutral600)
       
       Spacer()
       
@@ -75,6 +77,7 @@ struct LoginView: View {
           Image(icon)
         
           Text(title)
+            .suit(.medium, size: 15)
             .foregroundStyle(textColor)
         }
       }


### PR DESCRIPTION
## 🛠 변경 사항 Changes
- **폰트 모디파이어 적용**
- **전체적인 배치 변경 ( 아이콘, 글자 )** 
- **버튼 배치 변경**

## 💬 기타 참고 사항
- 피그마에서 각 요소의 레이아웃 값을 보고 배치하였습니다.

## 🔗 관련 이슈 Related issues
closes #14 

## 궁금한 점
<img width="284" alt="스크린샷 2025-02-03 오후 8 46 06" src="https://github.com/user-attachments/assets/aa2f0c7c-c2a6-41ad-8916-5da4a17d8a3d" />

**요소들간의 간격(텍스트 간, 버튼 간)은 레이아웃에서 안보이던데 따로 볼 수 있는 방법이 있나요 ?** ( 해결 ) -> ( 마우스 + 옵션키 )

지금까지는 아래와 같은 방법으로 패딩 값 구했습니다 😢
**( 아래 요소 레이아웃 : Top ) - ( 위 요소 레이아웃 : Top ) - ( 위 요소 레이아웃 : Height )** 

## 📸 스크린샷 (선택 사항)
<p align="center">
  <figure>
    <img width="229" alt="스크린샷1" src="https://github.com/user-attachments/assets/64a200fa-3a7a-49e7-bb17-cf9b1441b67a" />
    <figcaption>📌 기존 UI</figcaption>
  </figure>
  <figure>
    <img width="251" alt="스크린샷2" src="https://github.com/user-attachments/assets/169a800e-7589-487c-99d6-0b5a31c1813f" />
    <figcaption>✅ 수정된 UI</figcaption>
  </figure>
</p>


